### PR TITLE
(#8) do not confuse certname and identity

### DIFF
--- a/filesec/util.go
+++ b/filesec/util.go
@@ -1,6 +1,10 @@
 package filesec
 
-import "regexp"
+import (
+	"os"
+	"regexp"
+	"runtime"
+)
 
 // MatchAnyRegex checks str against a list of possible regex, if any match true is returned
 func MatchAnyRegex(str []byte, regex []string) bool {
@@ -11,4 +15,20 @@ func MatchAnyRegex(str []byte, regex []string) bool {
 	}
 
 	return false
+}
+
+func uid() int {
+	if useFakeUID {
+		return fakeUID
+	}
+
+	return os.Geteuid()
+}
+
+func runtimeOs() string {
+	if useFakeOS {
+		return fakeOS
+	}
+
+	return runtime.GOOS
 }

--- a/puppetsec/puppet_security_test.go
+++ b/puppetsec/puppet_security_test.go
@@ -153,18 +153,6 @@ var _ = Describe("PuppetSSL", func() {
 
 			Expect(prov.Identity()).To(Equal("bob.choria"))
 		})
-
-		It("Should support non root users", func() {
-			cfg.Identity = ""
-			os.Setenv("USER", "bob")
-			Expect(prov.Identity()).To(Equal("bob.mcollective"))
-		})
-
-		It("Should support root users", func() {
-			cfg.fakeUID = 0
-			cfg.Identity = "node.example.net"
-			Expect(prov.Identity()).To(Equal("node.example.net"))
-		})
 	})
 
 	Describe("cachePath", func() {

--- a/puppetsec/util.go
+++ b/puppetsec/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 func userSSlDir() (string, error) {
-	if os.Getuid() == 0 {
+	if os.Geteuid() == 0 {
 		path, err := puppet.Setting("ssldir")
 		if err != nil {
 			return "", err


### PR DESCRIPTION
While creating these providers we confused the concepts of certname
and identity - because here we used a variable Identity to store
what really is a certname, it makes sense to use that name here though

As a result we ended up in situation where for non root users the
certname would be the fqdn of the machine - or configured identity

That's wrong, we now do a better job of seperating these concepts
and hopefully make handling this a bit more robust