### PR TITLE
(#16) Validate before caching

### DIFF
--- a/filesec/file_security_test.go
+++ b/filesec/file_security_test.go
@@ -504,6 +504,23 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stat.Size()).To(Equal(int64(16)))
 		})
+
+		It("Should fail cache validation if allow lists change", func() {
+			cfg.Cache = os.TempDir()
+			cfg.Cache = os.TempDir()
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = prov.CachePublicData(pd, "rip.mcollective")
+			Expect(err).ToNot(HaveOccurred())
+
+			cfg.AllowList = []string{"^bees$"}
+
+			err = prov.CachePublicData(pd, "rip.mcollective")
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Describe("CachedPublicData", func() {


### PR DESCRIPTION
* If you change the allow list, a cached cert will be allowed for non-privileged actions.  This is not intuitive.

* Fixed a typo, and making tests pass locally.

Fixes #16 