### PR TITLE
(#22) support slashes in regex

### DIFF
--- a/filesec/util.go
+++ b/filesec/util.go
@@ -4,11 +4,17 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strings"
 )
 
 // MatchAnyRegex checks str against a list of possible regex, if any match true is returned
 func MatchAnyRegex(str []byte, regex []string) bool {
 	for _, reg := range regex {
+		if matched, _ := regexp.MatchString("^/.+/$", reg); matched {
+			reg = strings.TrimLeft(reg, "/")
+			reg = strings.TrimRight(reg, "/")
+		}
+
 		if matched, _ := regexp.Match(reg, str); matched {
 			return true
 		}

--- a/filesec/util_test.go
+++ b/filesec/util_test.go
@@ -1,0 +1,19 @@
+package filesec
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MatchAnyRegex", func() {
+	It("Should correctly match valid patterns", func() {
+		patterns := []string{
+			"bare",
+			"/this.+other/",
+		}
+
+		Expect(MatchAnyRegex([]byte("this is a bare word sentence"), patterns)).To(BeTrue())
+		Expect(MatchAnyRegex([]byte("this, that and the other"), patterns)).To(BeTrue())
+		Expect(MatchAnyRegex([]byte("no match"), patterns)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
In the ruby code we support regex config like 'foo, /bar/' this was
not supported here, this change supports those in the same way the
ruby side did