### PR TITLE
(#29) amend validation order to prioritise privileged certs

### DIFF
--- a/filesec/file_security.go
+++ b/filesec/file_security.go
@@ -273,12 +273,12 @@ func (s *FileSecurity) VerifyStringSignature(str string, sig []byte, identity st
 func (s *FileSecurity) PrivilegedVerifyByteSignature(dat []byte, sig []byte, identity string) bool {
 	var candidates []string
 
-	if identity != "" {
-		candidates = append(candidates, identity)
-	}
-
 	for _, candidate := range s.privilegedCerts() {
 		candidates = append(candidates, candidate)
+	}
+
+	if identity != "" {
+		candidates = append(candidates, identity)
 	}
 
 	for _, candidate := range candidates {

--- a/filesec/file_security_test.go
+++ b/filesec/file_security_test.go
@@ -110,8 +110,8 @@ var _ = Describe("FileSSL", func() {
 			prov, err := New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})))
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(prov.conf.AllowList).To(Equal([]string{"\\.mcollective$"}))
-			Expect(prov.conf.PrivilegedUsers).To(Equal([]string{"\\.privileged.mcollective$"}))
+			Expect(prov.conf.AllowList).To(Equal([]string{"\\.mcollective$", "\\.choria$"}))
+			Expect(prov.conf.PrivilegedUsers).To(Equal([]string{"\\.privileged.mcollective$", "\\.privileged.choria$"}))
 			Expect(prov.conf.CA).To(Equal("stub/ca.pem"))
 			Expect(prov.conf.Cache).To(Equal("stub/cache"))
 			Expect(prov.conf.Certificate).To(Equal("stub/cert.pem"))

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 2a412acb3adac850adf2684018e2b5e8530cf2fff05952a31838b3f969673e50
-updated: 2018-11-15T09:36:00.562889-08:00
+updated: 2019-01-02T16:05:45.790253+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/choria-io/go-choria
-  version: 2ece4ea72ff60d44818365d0655832d2d7ff35c0
+  version: a5d51011f80fd5c6e96b0fd5384c5518c7fff40e
   subpackages:
   - build
   - config
@@ -42,15 +42,16 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/prometheus/client_golang
-  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  version: 505eaef017263e299324067d40ca2c48f6a2cf50
   subpackages:
   - prometheus
+  - prometheus/internal
 - name: github.com/prometheus/client_model
   version: 5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 41aa239b4cce3c56ab88fc366ae8b0a6423fa239
+  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -68,7 +69,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/sys
-  version: 66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399
+  version: f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733
   subpackages:
   - unix
 - name: gopkg.in/alecthomas/kingpin.v2
@@ -86,7 +87,7 @@ testImports:
   - watch
   - winfile
 - name: github.com/onsi/ginkgo
-  version: 3774a09d95489ccaa16032e0770d08ea77ba6184
+  version: 2e1be8f7d90e9d3e3e58b0ce470f2f14d075406f
   subpackages:
   - config
   - internal/codelocation
@@ -106,7 +107,7 @@ testImports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 7615b9433f86a8bdf29709bf288bc4fd0636a369
+  version: 65fb64232476ad9046e57c26cd0bff3d3a8dc6cd
   subpackages:
   - format
   - internal/assertion

--- a/puppetsec/puppet_security_test.go
+++ b/puppetsec/puppet_security_test.go
@@ -112,8 +112,8 @@ var _ = Describe("PuppetSSL", func() {
 			prov, err = New(WithChoriaConfig(c), WithResolver(resolver), WithLog(l.WithFields(logrus.Fields{})))
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(prov.conf.AllowList).To(Equal([]string{"\\.mcollective$"}))
-			Expect(prov.conf.PrivilegedUsers).To(Equal([]string{"\\.privileged.mcollective$"}))
+			Expect(prov.conf.AllowList).To(Equal([]string{"\\.mcollective$", "\\.choria$"}))
+			Expect(prov.conf.PrivilegedUsers).To(Equal([]string{"\\.privileged.mcollective$", "\\.privileged.choria$"}))
 			Expect(prov.conf.DisableTLSVerify).To(BeTrue())
 			Expect(prov.conf.SSLDir).To(Equal("/stub"))
 			Expect(prov.conf.PuppetCAHost).To(Equal("stubhost"))


### PR DESCRIPTION
This does not change security in any way, simply optimise for certs
I think will exist most often on disk