### PR TITLE
(#27) ensure priv'd certificates are validated with the right names

### DIFF
--- a/filesec/file_security_test.go
+++ b/filesec/file_security_test.go
@@ -423,22 +423,27 @@ var _ = Describe("FileSSL", func() {
 		It("Should only accept valid certs signed by our ca", func() {
 			pd, err := ioutil.ReadFile(filepath.Join("..", "testdata", "foreign.pem"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "foo")).To(BeFalse())
+
+			should, name := prov.shouldCacheClientCert(pd, "foo")
+			Expect(should).To(BeFalse())
+			Expect(name).To(Equal("foo"))
 
 			pub := prov.publicCertPath()
 			pd, err = ioutil.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeTrue())
+
+			should, name = prov.shouldCacheClientCert(pd, "rip.mcollective")
+			Expect(should).To(BeTrue())
+			Expect(name).To(Equal("rip.mcollective"))
 		})
 
 		It("Should cache privileged certs", func() {
-			cfg.Identity = "1.privileged.mcollective"
-
-			pub := prov.publicCertPath()
-
-			pd, err := ioutil.ReadFile(pub)
+			pd, err := ioutil.ReadFile(filepath.Join("..", "testdata", "good", "certs", "1.privileged.mcollective.pem"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "1.privileged.mcollective")).To(BeTrue())
+
+			should, name := prov.shouldCacheClientCert(pd, "bob")
+			Expect(should).To(BeTrue())
+			Expect(name).To(Equal("1.privileged.mcollective"))
 		})
 
 		It("Should not cache certs with wrong names", func() {
@@ -446,7 +451,10 @@ var _ = Describe("FileSSL", func() {
 
 			pd, err := ioutil.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "bob")).To(BeFalse())
+
+			should, name := prov.shouldCacheClientCert(pd, "bob")
+			Expect(should).To(BeFalse())
+			Expect(name).To(Equal("bob"))
 		})
 
 		It("Should only cache certs thats on the allowed list", func() {
@@ -455,7 +463,10 @@ var _ = Describe("FileSSL", func() {
 
 			pd, err := ioutil.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeFalse())
+
+			should, name := prov.shouldCacheClientCert(pd, "rip.mcollective")
+			Expect(should).To(BeFalse())
+			Expect(name).To(Equal("rip.mcollective"))
 		})
 
 		It("Should cache valid certs", func() {
@@ -463,7 +474,10 @@ var _ = Describe("FileSSL", func() {
 
 			pd, err := ioutil.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeTrue())
+
+			should, name := prov.shouldCacheClientCert(pd, "rip.mcollective")
+			Expect(should).To(BeTrue())
+			Expect(name).To(Equal("rip.mcollective"))
 		})
 	})
 


### PR DESCRIPTION
Previously when a priv'd cert signed a request for 'bob' we would
end up checking if 'bob' was privilged instead of the names from
the certificate which would hold the priv'd cert.

Now we extract the common name and all the alt names and then check
each of those, if any of them are priv'd we assume the cert is also
priv'd and allow the request through without validating that caller
name equals cert name

In that case we also have to ensure that the priv'd cert that came
for user 'bob' is not cached as 'bob' but with the priv'd name, this
adjusts things so this will happen