### PR TITLE
(#36) only write certs when they change when always overwrite is set

### DIFF
--- a/filesec/file_security_test.go
+++ b/filesec/file_security_test.go
@@ -529,7 +529,7 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove(cpath)
 
-			// deliberatly change the file so that we can figure out if its being changed
+			// deliberately change the file so that we can figure out if its being changed
 			// I'd check time stamps but they are per second so not much use
 			err = ioutil.WriteFile(cpath, []byte("too many secrets"), os.FileMode(int(0644)))
 			Expect(err).ToNot(HaveOccurred())

--- a/filesec/util.go
+++ b/filesec/util.go
@@ -1,6 +1,8 @@
 package filesec
 
 import (
+	"crypto/sha256"
+	"io"
 	"os"
 	"regexp"
 	"runtime"
@@ -37,4 +39,20 @@ func runtimeOs() string {
 	}
 
 	return runtime.GOOS
+}
+
+func fsha256(file string) ([]byte, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
 }


### PR DESCRIPTION
This avoids write attempts when not needed making things a bit slower
but a bit more resiliant when disks are full etc